### PR TITLE
Update media_player.py

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -160,7 +160,7 @@ CONF_DISABLED_SOURCES   = 'disabled_sources'
 CONF_RADIO_STATIONS     = 'radio_stations'
 CONF_LAST_RADIO_STATION = 'last_radio_station'
 
-DATA_PIONEER = 'pioneer'
+DATA_PIONEER = 'asyncpioneer'
 ATTR_SPEAKER = 'speaker'
 ATTR_SPEAKER_CONFIG = 'speaker_config'
 SERVICE_SELECT_SPEAKER = 'pioneer_select_speaker'


### PR DESCRIPTION
Fixed issue with the latest version of HASS where it's unable to load the custom integration due to: "No ‘version’ key in the manifest file for custom integration"