### PR TITLE
Bufgfixes and additions for Home Assistant 2024.x / asyncio and support for VSX-922

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -7,13 +7,12 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA,
-    MediaPlayerEntity)
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature)
 
 from homeassistant.components.media_player.const import (
-    SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_SELECT_SOURCE,
-    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    MEDIA_TYPE_MUSIC, SUPPORT_PLAY_MEDIA, DOMAIN,
-    SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
+    DOMAIN,
+    MEDIA_TYPE_MUSIC,
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_INPUT_SOURCE,
@@ -150,11 +149,12 @@ _LOGGER = logging.getLogger(__name__)
 MAX_VOLUME = 185
 MAX_ZONE_VOLUME = 81
 
-CONNECT_RETRY_SECS = 15
-TIMEOUT_SECS = 10
+CONNECT_RETRY_SECS = 5
+TIMEOUT_SECS = 3
 
 DEFAULT_NAME = 'Pioneer AVR'
-DEFAULT_PORT = 8102   # Most Pioneer AVRs now use 8102
+DEFAULT_PORT = 8102     # Most Pioneer AVRs now use 8102
+ALTERNATE_PORT = 23     # Some Pioneer AVRs now use 23
 
 CONF_SERIAL_BRIDGE      = 'serial_bridge'
 CONF_DISABLED_SOURCES   = 'disabled_sources'
@@ -175,11 +175,11 @@ ATTR_HDMI_OUT = 'hdmi_out'
 SERVICE_SELECT_HDMI_OUT = 'pioneer_select_hdmi_out'
 SERVICE_SELECT_SOUND_MODE = 'select_sound_mode'
 
-SUPPORT_PIONEER = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-                  SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
-                  SUPPORT_SELECT_SOURCE | SUPPORT_PLAY | \
-                  SUPPORT_PLAY_MEDIA | \
-                  SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
+SUPPORT_PIONEER = MediaPlayerEntityFeature.PAUSE | MediaPlayerEntityFeature.PLAY | \
+                  MediaPlayerEntityFeature.SELECT_SOURCE | MediaPlayerEntityFeature.TURN_OFF | \
+                  MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.VOLUME_MUTE | \
+                  MediaPlayerEntityFeature.VOLUME_SET | MediaPlayerEntityFeature.PLAY_MEDIA | \
+                  MediaPlayerEntityFeature.NEXT_TRACK | MediaPlayerEntityFeature.PREVIOUS_TRACK
 
 MEDIA_PLAYER_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.comp_entity_ids,
@@ -338,8 +338,6 @@ async def async_setup_platform(hass, config, async_add_entities, \
     _LOGGER.debug("adding pio devices")
     async_add_entities(devices, update_before_add=False)
 
-
-
     async def async_service_handler(service):
         """Handle for services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
@@ -349,30 +347,30 @@ async def async_setup_platform(hass, config, async_add_entities, \
         else:
             devices = hass.data[DATA_PIONEER]
 
-        for device in devices:
+        for device in devices:  # type: PioneerDevice
             if service.service == SERVICE_SELECT_SPEAKER:
                 speaker = service.data.get(ATTR_SPEAKER)
-                device.select_speaker(speaker)
+                await device.select_speaker(speaker)
 
             if service.service == SERVICE_SELECT_SPEAKER_CONFIG:
                 speaker_config = service.data.get(ATTR_SPEAKER_CONFIG)
-                device.select_speaker_config(speaker_config)
+                await device.select_speaker_config(speaker_config)
 
             if service.service == SERVICE_SELECT_RADIO_STATION:
                 station = service.data.get(ATTR_STATION)
-                device.select_radio_station(station)
+                await device.select_radio_station(station)
 
             if service.service == SERVICE_DIM_DISPLAY:
                 dim_display = service.data.get(ATTR_DIM_DISPLAY)
-                device.dim_display(dim_display)
+                await device.dim_display(dim_display)
 
             if service.service == SERVICE_SELECT_HDMI_OUT:
                 hdmi_out = service.data.get(ATTR_HDMI_OUT)
-                device.select_hdmi_out(hdmi_out)
+                await device.select_hdmi_out(hdmi_out)
 
             if service.service == SERVICE_SELECT_SOUND_MODE:
                 sound_mode = service.data.get(ATTR_SOUND_MODE)
-                device.select_sound_mode(sound_mode)
+                await device.async_select_sound_mode(sound_mode)
 
             device.async_schedule_update_ha_state(True)
 
@@ -406,6 +404,7 @@ class PioneerDevice(MediaPlayerEntity):
     def __init__(self, hass, name, ip, port, serial_bridge,\
                  disabled_sources, last_radio_station, radio_stations, zone, hasZones, inputs):
         _LOGGER.debug("Init")
+        self.conn_lock = None
         self.port = port
         self.ip = ip
         self.serial_bridge = serial_bridge
@@ -463,16 +462,13 @@ class PioneerDevice(MediaPlayerEntity):
 
         hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, self.stop_pioneer)
 
-
     def stop_pioneer(self, event):
         _LOGGER.info("Shutting down Pioneer")
         self._stop_listen = True
 
-
     async def async_added_to_hass(self):
         _LOGGER.debug(f"{self._zone} Async async_added_to_hass")
         self._async_added = True
-
 
     async def getInputNames(self):
         _LOGGER.debug(f"{self._zone} Get Names")
@@ -486,11 +482,39 @@ class PioneerDevice(MediaPlayerEntity):
                     continue
 
             if source not in self._source_number_to_name:
-                self.telnet_command("?RGB" + source)
+                await self.telnet_command("?RGB" + source)
                 await asyncio.sleep(0.15)
                 hasNames = False
         self.hasNames = hasNames
 
+    async def close_connections(self):
+        if isinstance(self.writer, asyncio.StreamWriter):
+            self.writer.close()
+            await self.writer.wait_closed()
+
+    async def connect(self):
+
+        # if not isinstance(self.conn_lock, asyncio.Lock):
+        #     self.conn_lock = asyncio.Lock()
+
+        # just to be sure we didn't leave anything open
+        await self.close_connections()
+
+        # Try both ports. the VSX-922, for exapmle, likes to switch back and forth.
+        for port in [DEFAULT_PORT, ALTERNATE_PORT]:
+            try:
+                # async with self.conn_lock:
+                with async_timeout.timeout(TIMEOUT_SECS):
+                    self.reader, self.writer = \
+                        await asyncio.open_connection(self.ip, port)
+                self.hasConnection = True
+                _LOGGER.info(f"{self._zone} Connected to %s:%d", self.ip, port)
+                break
+            except ConnectionRefusedError as cr:
+                _LOGGER.info(f"{self._zone} No connection to %s:%d, retrying with next port",
+                             self.ip, port)
+                await asyncio.sleep(1)
+                continue
 
     async def readdata(self):
         _LOGGER.debug(f"{self._zone} Readdata")
@@ -498,11 +522,7 @@ class PioneerDevice(MediaPlayerEntity):
         while not self._stop_listen:
             if not self.hasConnection:
                 try:
-                    with async_timeout.timeout(TIMEOUT_SECS):
-                        self.reader, self.writer = \
-                            await asyncio.open_connection(self.ip, self.port)
-                    self.hasConnection = True
-                    _LOGGER.info(f"{self._zone} Connected to %s:%d", self.ip, self.port)
+                    await self.connect()
                 except:
                     _LOGGER.info(f"{self._zone} No connection to %s:%d, retry in {CONNECT_RETRY_SECS}s", \
                         self.ip, self.port)
@@ -773,29 +793,39 @@ class PioneerDevice(MediaPlayerEntity):
 
         return msg
 
-
-    def telnet_command(self, command):
+    async def telnet_command(self, command):
         _LOGGER.debug(f"{self._zone} Command: " + command)
 
-        if self.hasConnection:
-            if not self.writer:
-                _LOGGER.error("No writer available")
-                self.hasConnection = False
-                return
+        for i in range(10):
 
-            try:
-                 self.writer.write(command.encode("ASCII") + b"\r")
-                 if self.serial_bridge:
-                    sleep(0.1)
-            except (ConnectionRefusedError, OSError):
-                _LOGGER.error("Pioneer %s refused connection!", self._name)
-                self.hasConnection = False
-                return
-            except:
-                _LOGGER.error("Pioneer %s lost connection!", self._name)
-                self.hasConnection = False
-                self.clearDisplay()
-        return
+            if not self.hasConnection or not self.writer:
+                await self.connect()
+
+            if self.hasConnection:
+                if not self.writer:
+                    _LOGGER.error("No writer available")
+                    self.hasConnection = False
+                    continue
+
+                try:
+                     self.writer.write(command.encode("ASCII") + b"\r")
+                     if self.serial_bridge:
+                        await asyncio.sleep(0.1)
+                except (ConnectionRefusedError, OSError):
+                    _LOGGER.error("Pioneer %s refused connection!", self._name)
+                    self.hasConnection = False
+                    asyncio.sleep(0.3)
+                    _LOGGER.error("Retrying connection...", self._name)
+                except:
+                    _LOGGER.error("Pioneer %s lost connection!", self._name)
+                    self.hasConnection = False
+                    self.clearDisplay()
+                    asyncio.sleep(0.3)
+                    _LOGGER.error("Retrying connection...", self._name)
+
+                break
+
+            return
 
     async def async_update(self):
         """Get the latest details from the device."""
@@ -805,7 +835,7 @@ class PioneerDevice(MediaPlayerEntity):
         _LOGGER.debug(f"{self._zone} Update")
 
         if not self.hasDeviceName:
-            self.telnet_command("?RGD")
+            await self.telnet_command("?RGD")
 
         if not self.hasNames:
             await asyncio.sleep(1)
@@ -813,32 +843,32 @@ class PioneerDevice(MediaPlayerEntity):
 
         # Power state?
         commands = ["?P", "?AP", "?ZEP"]
-        self.telnet_command(commands[self._zone_index])
+        await self.telnet_command(commands[self._zone_index])
 
         if self._power:
             # Volume?
             commands = ["?V", "?ZV", "?HZV"]
-            self.telnet_command(commands[self._zone_index])
+            await self.telnet_command(commands[self._zone_index])
 
             # Muted?
             commands = ["?M", "?Z2M", "?HZM"]
-            self.telnet_command(commands[self._zone_index])
+            await self.telnet_command(commands[self._zone_index])
 
             # Input source?
             commands = ["?F", "?ZS", "?ZEA"]
-            self.telnet_command(commands[self._zone_index])
+            await self.telnet_command(commands[self._zone_index])
 
             if self._zone == "Main":
                 # Speaker?
-                self.telnet_command("?SPK")
+                await self.telnet_command("?SPK")
 
             if self._selected_source_id == SOURCE_ID_TUNER:
-                self.telnet_command("?PR")  # Tuner preset?
-                self.telnet_command("?FR")  # Tuner frequency?
+                await self.telnet_command("?PR")  # Tuner preset?
+                await self.telnet_command("?FR")  # Tuner frequency?
             else:
-                self.telnet_command("?HO")  # HDMI out?
+                await self.telnet_command("?HO")  # HDMI out?
 
-            self.telnet_command("?S")       # Sound mode?
+            await self.telnet_command("?S")       # Sound mode?
 
         return True
 
@@ -939,7 +969,7 @@ class PioneerDevice(MediaPlayerEntity):
         return ""
 
 
-    def media_play(self):
+    async def async_media_play(self):
         """Start or resume playback on current source."""
         command = ""
         if self._selected_source_id == SOURCE_ID_TUNER:
@@ -954,12 +984,12 @@ class PioneerDevice(MediaPlayerEntity):
             command = "10NW"
 
         if command>"":
-            self.telnet_command(command)
+            await self.telnet_command(command)
             self.clearDisplay()
         else:
             _LOGGER.error("No play command for source %s",self._selected_source)
 
-    def media_pause(self):
+    async def async_media_pause(self):
         """Pause playback on current source."""
         command = ""
         if self._selected_source_id == SOURCE_ID_TUNER:
@@ -974,12 +1004,12 @@ class PioneerDevice(MediaPlayerEntity):
             command = "11NW"
 
         if command>"":
-            self.telnet_command(command)
+            await self.telnet_command(command)
         else:
             _LOGGER.error("No pause command for source %s", \
                 self._selected_source)
 
-    def media_previous_track(self):
+    async def async_media_previous_track(self):
         """Skip to previous track on current source."""
         command = ""
         if self._selected_source_id == SOURCE_ID_TUNER:
@@ -997,13 +1027,13 @@ class PioneerDevice(MediaPlayerEntity):
             command = "12NW"
 
         if command>"":
-            self.telnet_command(command)
+            await self.telnet_command(command)
             self.clearDisplay()
         else:
             _LOGGER.error("No 'previous track' command for source %s", \
                 self._selected_source)
 
-    def media_next_track(self):
+    async def async_media_next_track(self):
         """Skip to next track on current source."""
         command = ""
         if self._selected_source_id == SOURCE_ID_TUNER:
@@ -1022,86 +1052,86 @@ class PioneerDevice(MediaPlayerEntity):
             command = "13NW"
 
         if command>"":
-            self.telnet_command(command)
+            await self.telnet_command(command)
             self.clearDisplay()
         else:
             _LOGGER.error("No 'next track' command for source %s", \
                 self._selected_source_name)
 
-    def turn_off(self):
+    async def async_turn_off(self):
         """Turn off media player."""
         _LOGGER.debug(f"{self._zone} Turn off ")
         self.clearDisplay()
         commands = ["PF", "APF", "ZEF"]
-        self.telnet_command(commands[self._zone_index])
+        await self.telnet_command(commands[self._zone_index])
 
-    def volume_up(self):
+    async def async_volume_up(self):
         """Volume up media player."""
         _LOGGER.debug("Volume up ")
         commands = ["VU", "ZU", "HZU"]
-        self.telnet_command(commands[self._zone_index])
+        await self.telnet_command(commands[self._zone_index])
 
-    def volume_down(self):
+    async def async_volume_down(self):
         """Volume down media player."""
         _LOGGER.debug("Volume down ")
         commands = ["VD", "ZD", "HZD"]
-        self.telnet_command(commands[self._zone_index])
+        await self.telnet_command(commands[self._zone_index])
 
-    def set_volume_level(self, volume):
+    async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         # 60dB max
         if self._zone == "Main":
             _LOGGER.debug("Set volume to "+str(volume) \
                 +", so to "+str(round(volume * MAX_VOLUME)).zfill(3)+"VL")
-            self.telnet_command(str(round(volume * MAX_VOLUME)).zfill(3) + "VL")
+            await self.telnet_command(str(round(volume * MAX_VOLUME)).zfill(3) + "VL")
         elif self._zone == "Zone2":
             _LOGGER.debug("Set Zone2 volume to "+str(volume) \
                 +", so to ZV"+str(round(volume * MAX_ZONE_VOLUME)).zfill(2))
-            self.telnet_command(str(round(volume * MAX_ZONE_VOLUME)).zfill(2) + "ZV")
+            await self.telnet_command(str(round(volume * MAX_ZONE_VOLUME)).zfill(2) + "ZV")
         elif self._zone == "HDZone":
             _LOGGER.debug("Set HDZone volume to "+str(volume) \
                 +", so to "+str(round(volume * MAX_ZONE_VOLUME)).zfill(2)+"HZV")
-            self.telnet_command(str(round(volume * MAX_ZONE_VOLUME)).zfill(2) + "HZV")
+            await self.telnet_command(str(round(volume * MAX_ZONE_VOLUME)).zfill(2) + "HZV")
 
-    def mute_volume(self, mute):
+    async def async_mute_volume(self, mute: bool):
         """Mute (true) or unmute (false) media player."""
         if self._zone == "Main":
-            self.telnet_command("MO" if mute else "MF")
+            await self.telnet_command("MO" if mute else "MF")
         elif self._zone == "Zone2":
-            self.telnet_command("Z2MO" if mute else "Z2MF")
+            await self.telnet_command("Z2MO" if mute else "Z2MF")
         elif self._zone == "HDZone":
-            self.telnet_command("HZMO" if mute else "HZMF")
+            await self.telnet_command("HZMO" if mute else "HZMF")
 
-    def turn_on(self):
+    async def async_turn_on(self):
         """Turn the media player on."""
         _LOGGER.debug(f"{self._zone} Turn on ")
         self.clearDisplay()
         commands = ["PO", "APO", "ZEO"]
-        self.telnet_command(commands[self._zone_index])
+        await self.telnet_command(commands[self._zone_index])
 
-    def select_source(self, source):
+    async def async_select_source(self, source):
         """Select input source."""
         if source in self._source_name_to_number:
             commands = ["FN", "ZS", "ZEA"]
-            self.telnet_command(self._source_name_to_number.get(source) + commands[self._zone_index])
+            await self.telnet_command(self._source_name_to_number.get(source) + commands[self._zone_index])
             self.clearDisplay()
         else:
             _LOGGER.error("Unknown input '%s'", source)
 
-    def select_speaker(self, speaker):
+    async def select_speaker(self, speaker):
         """Select output speaker."""
         if speaker in ACCEPTED_SPEAKER_VALUES:
             index = ACCEPTED_SPEAKER_VALUES.index(speaker)
-            self.telnet_command(str(index+1)+"SPK")
+            await self.telnet_command(str(index+1)+"SPK")
 
-    def select_speaker_config(self, speaker_config):
+    async def select_speaker_config(self, speaker_config):
         """Select speaker config mode."""
         _LOGGER.debug(f"Speaker config '{speaker_config}'")
         if speaker_config in ACCEPTED_SPEAKER_CONFIG_VALUES:
             index = ACCEPTED_SPEAKER_CONFIG_VALUES.index(speaker_config)
-            self.telnet_command("0"+str(index)+"SSF")
+            await self.telnet_command("0"+str(index)+"SSF")
 
-    def select_radio_station(self, station):
+    async def select_radio_station(self, station):
         """Set radio tuner to the frequency of a named station in config."""
         if not len(self._radio_stations) \
             or not station in self._radio_stations.keys():
@@ -1109,20 +1139,20 @@ class PioneerDevice(MediaPlayerEntity):
         else:
             num = self._radio_stations.get(station)
             if num > "":
-                self.telnet_command(num + "PR")
+                await self.telnet_command(num + "PR")
                 self.clearDisplay()
                 _LOGGER.debug("Set radio preset to '%s' for station '%s'", \
                     num, station)
 
-    def select_hdmi_out(self, hdmi_out):
+    async def select_hdmi_out(self, hdmi_out):
         """Select hdmi output."""
         _LOGGER.debug("HDMI command received '%s'", hdmi_out)
         if hdmi_out in ACCEPTED_HDMI_OUT_VALUES:
             index = ACCEPTED_HDMI_OUT_VALUES.index(hdmi_out)
             _LOGGER.debug("HDMI command will be '%d'", index)
-            self.telnet_command(str(index)+"HO")
+            await self.telnet_command(str(index)+"HO")
 
-    def select_sound_mode(self, sound_mode):
+    async def async_select_sound_mode(self, sound_mode):
         """Select sound mode"""
         _LOGGER.debug("Sound mode command received '%s'", sound_mode)
         foundMode = False
@@ -1130,13 +1160,13 @@ class PioneerDevice(MediaPlayerEntity):
             if name == sound_mode:
                 foundMode = True
                 _LOGGER.debug("Sound mode command will be '%s'", code)
-                self.telnet_command(code+"SR")
+                await self.telnet_command(code+"SR")
         if not foundMode:
             _LOGGER.debug("Cannot find code for sound mode '%s'", sound_mode)
 
-    def dim_display(self, dim_display):
+    async def dim_display(self, dim_display):
         """Dims the display"""
-        self.telnet_command(str(dim_display)+"SAA")
+        await self.telnet_command(str(dim_display)+"SAA")
 
     @property
     def state_attributes(self):


### PR DESCRIPTION
Please apologize for this big commit with many - partly unrelated - changes in one.
But I figured that maybe others could benefit from it too.
After my changes, the receiver works reliably now for some weeks.

Please note that all credits belong to https://github.com/realthk/asyncpioneer

I just updated some of the code to:

- Make it work with my Pioneer VSX-922:
  - it used to vanish after a while and never be found anymore, except after some restarts.
  - I found out that the problem was that the receiver sort of randomly switches between listening to port 23 and 8102. I don't know if this applies to other models too, but judjing from some forum posts, it is likely. The component now tries both ports in sequence, at every connect. In this version, the port added to the configuration yaml is basically ignored.
  - I also made sure that it will try reconnects whenever the connection is lost (a few cases were left off in the original)
- Remove warnings on hassio 2024.* by:
  - make all calls asyncio-compatible
  - update the supported_features to use the MediaPlayerEntityFeature-prefixed features